### PR TITLE
modification to allow immediate authentification

### DIFF
--- a/app/templates/src/main/webapp/scripts/components/auth/_auth.service.js
+++ b/app/templates/src/main/webapp/scripts/components/auth/_auth.service.js
@@ -14,9 +14,8 @@ angular.module('<%=angularAppName%>')
                         // the language selected by the user during his registration
                         $translate.use(account.langKey);<% if (websocket == 'spring-websocket') { %>
                         Tracker.sendActivity();<% } %>
+                        deferred.resolve(data);
                     });
-                    deferred.resolve(data);
-
                     return cb();
                 }).catch(function (err) {
                     this.logout();


### PR DESCRIPTION
The user was authentified only after refreshing the page, and the immediate redirection (after the click on "Login") on a page needing an authentified user was impossible.
